### PR TITLE
Run the right test file

### DIFF
--- a/plugin/phpunit.vim
+++ b/plugin/phpunit.vim
@@ -108,7 +108,10 @@ endfun
 
 fun! g:PHPUnit.RunCurrentFile()
   let cmd = g:PHPUnit.buildBaseCommand()
-  let cmd = cmd +  [bufname("%")]
+  let currentfile = bufname("%")
+  let currentfile = substitute(currentfile,".php","Test.php","")
+  let testfile = substitute(currentfile, g:phpunit_srcroot, g:phpunit_testroot, "")
+  let cmd = cmd + [testfile]
   silent call g:PHPUnit.Run(cmd, bufname("%")) 
 endfun
 fun! g:PHPUnit.RunTestCase(filter)


### PR DESCRIPTION
I believe this fixes this issue https://github.com/c9s/phpunit.vim/issues/2.

### Context
I tried to run the test class that matches with the current source class, but it didn't work.
And I get this error:

```
Fatal error: Uncaught PHPUnit\Runner\Exception: Class 'src/Somepath/SomeClass.php' could not be found in '/some/absolute/path' . in /var/www/zola-returns/vendor/phpunit/phpunit/src/Runner/StandardTestSuiteLoader.php:133.
```

### Technical tools
php: 7.4
vim: 8.2
PHPUnit: 8.4.3

@c9s Can you have a look at this please?